### PR TITLE
Fix load by alternate key with Automatic primary key

### DIFF
--- a/src/test/java/com/amazon/carbonado/TestStorables.java
+++ b/src/test/java/com/amazon/carbonado/TestStorables.java
@@ -3513,6 +3513,33 @@ public class TestStorables extends TestCase {
         }
     }
 
+    public void test_loadByAltKeyWithAutomatic() throws Exception {
+        Storage<AutomaticAndAltKey> storage =
+                getRepository().storageFor(AutomaticAndAltKey.class);
+
+        // Insert a couple of records, starting with id=1.
+        // Note: manually set the Automatic ID property because not every
+        //       Repository type will set it automatically.
+        for (int i=1; i <= 2; i++) {
+            AutomaticAndAltKey record = storage.prepare();
+            record.setID(i);
+            record.setName("row" + i);
+            record.insert();
+        }
+
+        // Load an existing record.
+        AutomaticAndAltKey record = storage.prepare();
+        record.setName("row2");
+        assertTrue(record.tryLoad());
+        assertEquals(2, record.getID());
+        assertEquals("row2", record.getName());
+
+        // Load a non-existent record.
+        record = storage.prepare();
+        record.setName("row3");
+        assertFalse(record.tryLoad());
+    }
+
     private void assertUninitialized(boolean expected, Storable storable, String... properties) {
         for (String property : properties) {
             assertEquals(expected, storable.isPropertyUninitialized(property));

--- a/src/test/java/com/amazon/carbonado/repo/jdbc/H2SchemaResolver.java
+++ b/src/test/java/com/amazon/carbonado/repo/jdbc/H2SchemaResolver.java
@@ -135,6 +135,10 @@ public class H2SchemaResolver implements SchemaResolver {
                 b.append(" NOT NULL");
             }
 
+            if (property.isAutomatic()) {
+                b.append(" AUTO_INCREMENT");
+            }
+
             if (property.getSequenceName() != null) {
                 sequenceNames.add(property.getSequenceName());
             }

--- a/src/test/java/com/amazon/carbonado/repo/jdbc/TestH2.java
+++ b/src/test/java/com/amazon/carbonado/repo/jdbc/TestH2.java
@@ -25,6 +25,7 @@ import java.io.*;
 
 import java.sql.DriverManager;
 
+import com.amazon.carbonado.stored.AutomaticAndAltKey;
 import junit.framework.TestSuite;
 
 import org.apache.commons.dbcp.BasicDataSource;
@@ -74,6 +75,36 @@ public class TestH2 extends com.amazon.carbonado.TestStorables {
                 cap2.setAutoShutdownEnabled(false);
             }
             cap.getConnection().createStatement().execute("SHUTDOWN IMMEDIATELY");
+        }
+    }
+
+    public void test_automaticProperty() throws Exception {
+        Storage<AutomaticAndAltKey> storage =
+                getRepository().storageFor(AutomaticAndAltKey.class);
+
+        // Insert some record and expect the ID to be set automatically.
+        for (int i=1; i <= 5; i++) {
+            AutomaticAndAltKey record = storage.prepare();
+            record.setName("row" + i);
+            record.insert();
+        }
+
+        // Load by primary key
+        for (int i=1; i <= 5; i++) {
+            AutomaticAndAltKey record = storage.prepare();
+            record.setID(i);
+            assertTrue(record.tryLoad());
+            assertEquals(i, record.getID());
+            assertEquals("row" + i, record.getName());
+        }
+
+        // Load by alternate key
+        for (int i=1; i <= 5; i++) {
+            AutomaticAndAltKey record = storage.prepare();
+            record.setName("row" + i);
+            assertTrue(record.tryLoad());
+            assertEquals(i, record.getID());
+            assertEquals("row" + i, record.getName());
         }
     }
 

--- a/src/test/java/com/amazon/carbonado/stored/AutomaticAndAltKey.java
+++ b/src/test/java/com/amazon/carbonado/stored/AutomaticAndAltKey.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2006-2018 Amazon Technologies, Inc. or its affiliates.
+ * Amazon, Amazon.com and Carbonado are trademarks or registered trademarks
+ * of Amazon Technologies, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.carbonado.stored;
+
+import com.amazon.carbonado.AlternateKeys;
+import com.amazon.carbonado.Automatic;
+import com.amazon.carbonado.Key;
+import com.amazon.carbonado.PrimaryKey;
+import com.amazon.carbonado.Storable;
+
+/**
+ *
+ *
+ * @author Jesse Morgan
+ */
+@PrimaryKey("ID")
+@AlternateKeys(@Key("name"))
+public interface AutomaticAndAltKey extends Storable {
+    @Automatic
+    int getID();
+    void setID(int id);
+
+    String getName();
+    void setName(String name);
+}


### PR DESCRIPTION
Storables ignore @Automatic properties when checking if the primary key
is initialized. This makes sense for insert, because the Repository is
responsible for populating the @Automatic property. However, this doesn't
work for load--when the @Automatic property is also the primary key--
because it won't attempt to load by alternate key when it must.

These are the tests for https://github.com/Carbonado/Carbonado/pull/7